### PR TITLE
fixing Crosshair 

### DIFF
--- a/HarmonyPatches/CrossHairPatch.cs
+++ b/HarmonyPatches/CrossHairPatch.cs
@@ -1,5 +1,8 @@
+using System.Runtime.CompilerServices;
 using HarmonyLib;
 using NLog;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.GauntletUI;
 using TaleWorlds.MountAndBlade.GauntletUI.Widgets;
 using TaleWorlds.MountAndBlade.ViewModelCollection.HUD;
@@ -14,10 +17,21 @@ namespace TOW_Core.HarmonyPatches
         [HarmonyPatch(typeof(MissionGauntletCrosshair), "GetShouldCrosshairBeVisible")]
         public static void PostFix(ref bool  __result)
         {
-            __result = true;
+            if (!Mission.Current.IsLoadingFinished)
+                return;
+
+            if (Mission.Current.MainAgent !=null && Mission.Current.MainAgent.WieldedWeapon.Ammo>0)
+            {
+                __result = true;
+            }
+            else
+            {
+                __result = false;
+            }
+
+
+
         }
-        
-        
         
     }
 }

--- a/HarmonyPatches/CrossHairPatch.cs
+++ b/HarmonyPatches/CrossHairPatch.cs
@@ -17,9 +17,6 @@ namespace TOW_Core.HarmonyPatches
         [HarmonyPatch(typeof(MissionGauntletCrosshair), "GetShouldCrosshairBeVisible")]
         public static void PostFix(ref bool  __result)
         {
-            if (!Mission.Current.IsLoadingFinished)
-                return;
-
             if (Mission.Current.MainAgent !=null && Mission.Current.MainAgent.WieldedWeapon.Ammo>0)
             {
                 __result = true;
@@ -28,9 +25,6 @@ namespace TOW_Core.HarmonyPatches
             {
                 __result = false;
             }
-
-
-
         }
         
     }


### PR DESCRIPTION
The Crosshair shouldn't be visible if the player is wielding a Sword, or the weapon is empty.

This fix was tested with an outrider gun.